### PR TITLE
Use fragment identifiers instead of URL parameters and other cahnges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # view-images
-View images on a webpage. Supports url parameters.  
+View images on a webpage. Supports url fragments.  
 Great for sharing images that use assets.scratch.mit.edu.    
 https://gosoccerboy5.github.io/view-images/

--- a/assets/css/stylesheet.css
+++ b/assets/css/stylesheet.css
@@ -1,14 +1,15 @@
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
-    background-color: powderblue;
+    background-color: #d0f6ff;
 }
 h1, h2, h3 {
     font-weight: 400;
 }
-input {
-    width: 500px;
+input:focus{
+    outline: 1px solid blue;
 }
 #output {
+    display: none;
     border: 2px solid grey;
     padding: 50px;
 }

--- a/assets/css/stylesheet.css
+++ b/assets/css/stylesheet.css
@@ -1,6 +1,7 @@
 body {
     font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
     background-color: #d0f6ff;
+    text-align: center;
 }
 h1, h2, h3 {
     font-weight: 400;
@@ -10,8 +11,7 @@ input:focus{
 }
 #output {
     display: none;
-    border: 2px solid grey;
-    padding: 50px;
+    padding: 18px;
 }
 a {
     color: blue;

--- a/index.html
+++ b/index.html
@@ -7,7 +7,8 @@
     </head>
     <body>
         <h1>View images</h1>
-        <h2>Paste a url into the box below, or use a url parameter (like <small>https://gosoccerboy5.github.io/view-images/?url=http://example.com/image.png</small>)</h2>
+        <!-- The hash at the end of a URL is offically called a fragment identifier. -->
+        <h2>Paste a url into the box below, or use a fragment identifier (like <small>https://gosoccerboy5.github.io/view-images#http://example.com/image.png</small>)</h2>
         <input id="input"> <button id="copy">Copy as url</button>
         <br>
         <br>
@@ -15,10 +16,7 @@
         <br><br><br>
         <a href="https://gosoccerboy5.github.io">Home</a> | This page is open source. <a href="https://github.com/gosoccerboy5/view-images">Improve this page.</a>
         <script>
-            const param = window.location.href.match(/[\?&]url=[^&]*/)?.[0].substring(5);
-            // I had a problem - URL parameters take too much time.
-            // So I used regex.
-            // Hopefully, I now have 0 problems, but that might change.
+            const hash = location.hash.slice(1); // location.hash returns "#http://example.com/image.png", so I used slice() to remove the hash.
             const input = document.querySelector("#input");
             const output = document.querySelector("#output");
             const button = document.querySelector("#copy");
@@ -29,13 +27,13 @@
                 }
             };
             input.focus();
-            if (param !== undefined) {
-                input.value = param;
+            if (hash !== undefined) {
+                input.value = hash;
                 input.onkeyup({keyCode: 13});
             }
             button.addEventListener("click", function() {
                 let oldValue = input.value;
-                input.value = "https://gosoccerboy5.github.io/view-images/?url=" + oldValue;
+                input.value = "https://gosoccerboy5.github.io/view-images#" + oldValue;
                 input.select();
                 document.execCommand("copy");
                 input.value = oldValue;

--- a/index.html
+++ b/index.html
@@ -3,16 +3,16 @@
     <head>
         <title>View images</title>
         <meta charset="utf-8">
+        <meta name="viewpoint" content="width=device-width, initial-scale=1">
         <link rel = "stylesheet" type="text/css" href="assets/css/stylesheet.css">
     </head>
     <body>
         <h1>View images</h1>
-        <!-- The hash at the end of a URL is offically called a fragment identifier. -->
         <h2>Paste a url into the box below, or use a fragment identifier (like <small>https://gosoccerboy5.github.io/view-images#http://example.com/image.png</small>)</h2>
         <input id="input" size="70"> <button id="copy">Copy as url</button>
         <br>
         <br>
-        <img id="output">
+        <img id="output" src="about:blank" alt="Invalid image URL." width="auto" height="auto">
         <br><br><br>
         <a href="https://gosoccerboy5.github.io">Home</a> | This page is open source. <a href="https://github.com/gosoccerboy5/view-images">Improve this page.</a>
         <script>
@@ -22,8 +22,16 @@
             const button = document.querySelector("#copy");
             input.onkeyup = function(event) {
                 if (event.keyCode === 13 && input.value !== "") {
+                    location.hash = input.value
                     output.style.display = "inline";
-                    output.src = input.value;
+                    output.src = input.value; // For some reson using the hash variable didn't work.
+                    output.onload = function() {
+                        if (output.naturalWidth > (95 / 100) * window.innerWidth) { // Check if the image is wider than 95% of the window's width
+                            output.style.width="95%";
+                        } else {
+                            output.style.width="auto";
+                        }
+                    }
                 }
             };
             input.focus();

--- a/index.html
+++ b/index.html
@@ -9,10 +9,10 @@
         <h1>View images</h1>
         <!-- The hash at the end of a URL is offically called a fragment identifier. -->
         <h2>Paste a url into the box below, or use a fragment identifier (like <small>https://gosoccerboy5.github.io/view-images#http://example.com/image.png</small>)</h2>
-        <input id="input"> <button id="copy">Copy as url</button>
+        <input id="input" size="70"> <button id="copy">Copy as url</button>
         <br>
         <br>
-        <img style="display: none;" id="output">
+        <img id="output">
         <br><br><br>
         <a href="https://gosoccerboy5.github.io">Home</a> | This page is open source. <a href="https://github.com/gosoccerboy5/view-images">Improve this page.</a>
         <script>
@@ -22,7 +22,7 @@
             const button = document.querySelector("#copy");
             input.onkeyup = function(event) {
                 if (event.keyCode === 13 && input.value !== "") {
-                    output.style.display = "";
+                    output.style.display = "inline";
                     output.src = input.value;
                 }
             };


### PR DESCRIPTION
<!-- Which issue(s) does this pull request fix or resolve? -->

Resolves nothing.

### Changes

<!-- Please describe the changes you've made. -->

- Use fragment identifiers instead of URL parameters
- Adjust background colour
- Centre things on the page
- Add an `alt` and `src` to the `output` image
- Resize the image if they are over 95% of the window width
- Reduce image padding

### Reason for changes

<!-- Why should these changes be made? -->

 Using fragment identifiers make the URLs shorter than using URL parameters. and window overflowing images are annoying. For the rest, I just thought it would improve the page overall.

### Tests

<!-- If applicable. Have you tested this pull request? If so, how? -->

Tested locally.

### Additional Info

I don't have much experience in making PRs, and haven't contributed to many repositories so it's OK if you don't want to accept this.